### PR TITLE
fix(filenames): content hash query string

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -232,9 +232,7 @@ export default {
       chunk: ({ isDev, isModern }) =>
         isDev
           ? `[name]${isModern ? '.modern' : ''}.js`
-          : `[name].[contenthash:7]${
-              isModern ? '.modern' : ''
-            }.js?v=[contenthash:7]`,
+          : `[name]${isModern ? '.modern' : ''}.js?v=[contenthash:7]`,
       css: ({ isDev }) =>
         isDev ? '[name].css' : 'css/[name].css?v=[contenthash:7]',
       img: ({ isDev }) =>

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -224,6 +224,26 @@ export default {
   build: {
     transpile: ['lodash-es', 'vuetify/lib', 'vee-validate/dist/rules'],
     extractCSS: true,
+    filenames: {
+      app: ({ isDev, isModern }) =>
+        isDev
+          ? `[name]${isModern ? '.modern' : ''}.js`
+          : `[name].${isModern ? '.modern' : ''}.js?v=[contenthash:7]`,
+      chunk: ({ isDev, isModern }) =>
+        isDev
+          ? `[name]${isModern ? '.modern' : ''}.js`
+          : `[name].[contenthash:7]${
+              isModern ? '.modern' : ''
+            }.js?v=[contenthash:7]`,
+      css: ({ isDev }) =>
+        isDev ? '[name].css' : 'css/[name].css?v=[contenthash:7]',
+      img: ({ isDev }) =>
+        isDev ? '[path][name].[ext]' : 'img/[name].[ext]?v=[contenthash:7]',
+      font: ({ isDev }) =>
+        isDev ? '[path][name].[ext]' : 'fonts/[name].[ext]?v=[contenthash:7]',
+      video: ({ isDev }) =>
+        isDev ? '[path][name].[ext]' : 'videos/[name].[ext]?v=[contenthash:7]',
+    },
     extend(config, { isClient }) {
       // Extend only webpack config for client-bundle
       if (isClient) {


### PR DESCRIPTION
Removing the content hash from the file name means that there will always be a file on disk to serve. This prevents pages from breaking when the server no longer has an old version of an asset.

https://www.youtube.com/watch?v=tprJYFkv4LU